### PR TITLE
添加消息中间件默认的redis连接池配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ return [
     'test.consumer' => [
         'class' => \MeiQuick\Swoft\RabbitMq\Consumer\Consumer::class,
         'rabbit' => bean("rabbit.pool"),
-        'redis' => bean("messageRedis.pool"),  // redis配置的前缀必须是Message:（必须跟消息中间件的保持一致）
+        // redis配置的前缀必须是Message:（必须跟消息中间件的保持一致）
+        // 可以使用包预定义的配置（message.middleware.redis.pool）
+        'redis' => bean("message.middleware.redis.pool"),
         'exchangeName' => "test",  // 交换器
         'routeKey' => "/test",  // 路由键
         'queueName' => "test",  // 队列名称

--- a/src/AutoLoader.php
+++ b/src/AutoLoader.php
@@ -5,7 +5,6 @@
 namespace MeiQuick\Swoft\RabbitMq;
 
 use MeiQuick\Swoft\RabbitMq\Connection\ConnectionManager;
-use Swoft\Rpc\Packet;
 use Swoft\SwoftComponent;
 
 /**
@@ -48,7 +47,22 @@ class AutoLoader extends SwoftComponent
             ],
             'connection.manager' => [
                 'class'   => ConnectionManager::class
-            ]
+            ],
+            'message.middleware.redis' => [
+                'class' => \Swoft\Redis\RedisDb::class,
+                'host' => env('REDIS_HOST'),
+                'port' => env('REDIS_PORT'),
+                'password' => env('REDIS_PASSWORD'),
+                'database' => 1,
+                'option' => [
+                    'prefix' => "Message:",
+                    'serializer' => \Redis::SERIALIZER_NONE
+                ]
+            ],
+            'message.middleware.redis.pool' => [
+                'class' => \Swoft\Redis\Pool::class,
+                'redisDb' => bean('message.middleware.redis'),
+            ],
         ];
     }
 }


### PR DESCRIPTION
添加消息中间件默认的redis连接池配置，避免某些项目拉了这个包，没有配置对应的redis连接池报错